### PR TITLE
Fix Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,32 @@
+---
 language: python
 sudo: required
 dist: trusty
 cache:
-  directories:
-  - "$HOME/lxc"
+  directories: [ '$HOME/lxc' ]
   pip: true
 matrix:
   fast_finish: true
 env:
-#- LXC_DISTRO=debian LXC_RELEASE=jessie
-- LXC_DISTRO=debian LXC_RELEASE=stretch
-- LXC_DISTRO=ubuntu LXC_RELEASE=xenial
-#- LXC_DISTRO=centos LXC_RELEASE=7
-before_cache:
-- sudo mkdir $HOME/lxc && sudo tar cf $HOME/lxc/cache.tar /var/cache/lxc/ && sudo
-  chown $USER. $HOME/lxc/cache.tar
+- ANSIBLE_GIT_VERSION='devel' # 2.6.x development branch
+- ANSIBLE_VERSION='<2.6.0' # 2.5.x
 install:
-- sudo tar xf $HOME/lxc/cache.tar -C / || true
-- sudo apt-get install -y expect-dev
-- pip install ansible
+- if [ "$ANSIBLE_GIT_VERSION" ]; then pip install "https://github.com/ansible/ansible/archive/${ANSIBLE_GIT_VERSION}.tar.gz";
+  elif [ "$ANSIBLE_VERSION" ]; then pip install "ansible${ANSIBLE_VERSION}";
+  else pip install ansible; fi
 - ansible --version
-- printf '[defaults]\nroles_path=../\ncallback_whitelist=profile_tasks\nforks=10\npipelining=True' >ansible.cfg
-- ansible-galaxy install lae.travis-lxc geerlingguy.docker ben-le.awx_nginx
-- ansible-playbook -vvv tests/install.yml -i tests/inventory
+- ansible-galaxy install lae.travis-lxc lae.docker
+- ansible-playbook tests/install.yml -i tests/inventory
+- git archive --format tar.gz HEAD > ben-le.awx.tar.gz && ansible-galaxy install
+  ben-le.awx.tar.gz,$(git rev-parse HEAD),ben-le.awx && rm ben-le.awx.tar.gz
+before_script: cd tests/
 script:
-- ansible-playbook tests/deploy.yml -i tests/inventory --syntax-check
-- ansible-playbook tests/deploy.yml -i tests/inventory
-- 'ANSIBLE_STDOUT_CALLBACK=debug unbuffer ansible-playbook -vv tests/deploy.yml
-  -i tests/inventory >/tmp/idempotency.log 2>&1 ||
-  (e=$?; cat /tmp/idempotency.log; exit $e)'
-- 'grep -A1 "PLAY RECAP" /tmp/idempotency.log | grep -qP "changed=0.*failed=0" &&
-  (echo "Idempotence: PASS"; exit 0) ||
-  (echo "Idempotence: FAIL"; cat /tmp/idempotency.log; exit 1)'
-- ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook -v tests/test.yml -i tests/inventory
+- ansible-playbook -i inventory deploy.yml --syntax-check
+- ansible-playbook -i inventory deploy.yml
+- 'ANSIBLE_STDOUT_CALLBACK=debug unbuffer ansible-playbook -i inventory -vv
+  deploy.yml > idempotency.log 2>&1 || (e=$?; cat idempotency.log; exit $e)'
+- 'grep -A1 "PLAY RECAP" idempotency.log | grep -qP "changed=0 .*failed=0 .*" &&
+  (echo "Idempotence: PASS"; exit 0) || (echo "Idempotence: FAIL"; exit 1)'
+- ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook -i inventory -v test.yml
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/
-

--- a/tests/deploy.yml
+++ b/tests/deploy.yml
@@ -1,5 +1,5 @@
 ---
 - hosts: awx
-  become: true
-  roles: 
-    - ansible-role-awx
+  become: True
+  roles:
+    - ben-le.awx

--- a/tests/install.yml
+++ b/tests/install.yml
@@ -13,3 +13,34 @@
   become: True
   roles:
     - lae.docker
+  pre_tasks:
+    - name: Make cgroups modifiable
+      mount:
+        name: /sys/fs/cgroup
+        fstype: sysfs
+        src: sysfs
+        opts: rw
+        state: mounted
+
+    - name: Create missing cgroup directories
+      file:
+        path: "/sys/fs/cgroup/{{ item }}"
+        state: directory
+      with_items:
+        - cpu
+        - cpuacct
+        - net_cls
+        - net_prio
+
+    - name: Mount missing cgroups
+      mount:
+        name: "/sys/fs/cgroup/{{ item }}"
+        fstype: cgroup
+        src: cgroup
+        opts: "{{ item }}"
+        state: mounted
+      with_items:
+        - cpu
+        - cpuacct
+        - net_cls
+        - net_prio

--- a/tests/install.yml
+++ b/tests/install.yml
@@ -3,9 +3,13 @@
   connection: local
   roles:
     - lae.travis-lxc
+  vars:
+    test_profiles:
+      - profile: debian-stretch
+      - profile: ubuntu-xenial
+    lxc_use_overlayfs: no
 
 - hosts: awx
-  become: true
+  become: True
   roles:
-    - geerlingguy.docker
-    - ben-le.awx_nginx
+    - lae.docker

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,3 @@
 [awx]
-test01.lxc
+debian-stretch
+ubuntu-xenial

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,3 +1,3 @@
 [awx]
-debian-stretch
-ubuntu-xenial
+debian-stretch-01
+ubuntu-xenial-01


### PR DESCRIPTION
Latest version of Docker requires some specific cgroups, which the LXC package on Ubuntu 14 fails to map out to LXC containers. This adds the missing cgroups (it's just 4 out of like 12 or something), updates this role to use test profiles from the `lae.docker` role to test against Debian Stretch and Ubuntu Xenial, and also adds tests for the Ansible development branch.